### PR TITLE
Fix #14, "requires tensorboard to be installed" RuntimeError

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ packages = ["tsfm_public", "tsfm_public.toolkit", "tsfmhfdemos"]
 
 [project.optional-dependencies]
 
-notebooks = ["jupyter", "matplotlib", "datasets", "ipywidgets", "plotly", "kaleido"]
+notebooks = ["jupyter", "matplotlib", "datasets", "ipywidgets", "plotly", "kaleido", "tensorboard"]
 testing = ["pytest", "tsfm_public[notebooks]"]
 dev = ["pre-commit", "tsfm_public[testing]", "ruff==0.1.5"]
 evaluation = [


### PR DESCRIPTION
Update pyproject.toml to add `tensorboard` as a dependency of the `notebooks` target.

The tensorboard package is required for step 10 of `notebooks/patch_tsmixer_getting_started.ipynb` to run the following expression:

```
trainer = Trainer(
    model=model,
    args=train_args,
    train_dataset=train_dataset,
    eval_dataset=valid_dataset,
    callbacks=[early_stopping_callback],
)
```

Otherwise the following exception is raised:

```
RuntimeError: TensorBoardCallback requires tensorboard to be installed. Either update your PyTorch version or install tensorboardX.
```